### PR TITLE
💄 Style: 모달 뒷배경 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/ModalBackground.tsx
+++ b/src/components/ModalBackground.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function ModalBackground({
+  children,
+  onClose,
+}: {
+  children?: React.ReactNode;
+  onClose?: () => void;
+}) {
+  const handlecloseModal = (
+    event: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>,
+  ) => {
+    event.stopPropagation();
+    onClose();
+  };
+  return (
+    <div
+      className='fixed inset-0 z-5 w-full h-full flex justify-center items-center bg-[#1E3675CC] backdrop-blur-xs '
+      onClick={handlecloseModal}>
+      <div onClick={(e) => e.stopPropagation()}>
+        {/* children:  들어갈 모달 */}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,20 +1,37 @@
 import LayeredButton from '@components/LayeredButton';
 import { useToastStore } from '@/store/useToastStore';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import ModalBackground from '@components/ModalBackground';
 
 const MainPage = () => {
   const { showToast } = useToastStore();
   useEffect(() => {
     showToast('메인 페이지입니다.', 'error');
-  }
-  , [showToast]);
+  }, [showToast]);
+
+  const [isClicked, setIsClicked] = useState(false);
   return (
-    <div className='h-screen bg-blue-100'>
-      <div>MainPage</div>
-      <LayeredButton theme='red' className='w-20 h-20'>확인</LayeredButton>
-      <LayeredButton theme='gray'>메이트 취소</LayeredButton>
-      <LayeredButton theme='blue'>방 구경하기</LayeredButton>
-    </div>
+    <>
+      {isClicked && (
+        <ModalBackground onClose={() => setIsClicked(false)}>
+          <div className='w-[300px] h-[300px] p-10 bg-amber-400'>
+            <h1>모달창</h1>
+            <button onClick={() => setIsClicked(false)}>버튼 닫기</button>
+          </div>
+        </ModalBackground>
+      )}
+      <div className='h-screen bg-blue-100'>
+        <div>MainPage</div>
+        <button onClick={() => setIsClicked(true)}>모달창 띄우기</button>
+        <LayeredButton
+          theme='red'
+          className='w-20 h-20'>
+          확인
+        </LayeredButton>
+        <LayeredButton theme='gray'>메이트 취소</LayeredButton>
+        <LayeredButton theme='blue'>방 구경하기</LayeredButton>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`style/modalbackground` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명

일부 모달에서 공통으로 사용되는 모달 뒷배경을 퍼블리싱하였습니다.
취소버튼이 있다면 취소버튼과 모달의 바깥부분을 클릭하면 뒷배경이 사라지도록 구현하였습니다.



<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] MainPage에 뒷배경 반영
- [x] components/ModalBackground 추가
 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항

컴포넌트 사용법

- onClose prop: 모달창을 닫는 함수를 전달합니다.
- children: 띄워줄 모달 컴포넌트를 ModalBackground 컴포넌트안에 넣어 children으로 전달합니다.
![image](https://github.com/user-attachments/assets/c6b8755d-ccc5-406d-8661-b21a1f7e8835)


ModalBackground 컴포넌트
![image](https://github.com/user-attachments/assets/c3463fca-9f43-455a-8482-5136f9e057d5)

결과 화면
![image](https://github.com/user-attachments/assets/a6971374-df2b-42f6-acdd-955c79981767)


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
[이슈 번호/정보](이슈 url)