### PR TITLE
[fix/book-style] :sparkles:Feature: 등록된 도서 조회 로직 수정 및 책장 드래그 기능 추가

### DIFF
--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -45,7 +45,7 @@ export const bookAPI = {
   // ------------------------------ 책장 ------------------------------
   /**
    * 내 책장 조회
-   * @param roomId 방 ID
+   * @param userId 사용자 ID
    * @param pageSize 페이지 크기
    * @param lastBookId 마지막으로 조회한 책 ID (첫 페이지 조회 시 제외)
    * @returns 책장 목록
@@ -81,13 +81,13 @@ export const bookAPI = {
    * const nextPage = await bookAPI.getBookCaseList('1', 10, 2);
    */
   getBookCaseList: async (
-    roomId: string,
+    userId: string,
     pageSize: number,
     lastBookId?: number,
   ) => {
     const url = lastBookId
-      ? `/${API_URL}/mybooks?roomId=${roomId}&pageSize=${pageSize}&lastBookId=${lastBookId}`
-      : `/${API_URL}/mybooks?roomId=${roomId}&pageSize=${pageSize}`;
+      ? `/${API_URL}/mybooks?userId=${userId}&pageSize=${pageSize}&lastBookId=${lastBookId}`
+      : `/${API_URL}/mybooks?userId=${userId}&pageSize=${pageSize}`;
 
     const response = await axiosInstance.get(url);
     return response.data;

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -1,18 +1,103 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import ToolBoxButton from './components/ToolBoxButton';
 import { SearchModal } from '@components/search-modal/SearchModal';
 import BookCaseList from './components/BookCaseList';
+import { bookAPI } from '@apis/book';
+import { tokenService } from '@utils/token';
 
 const BookCasePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [books, setBooks] = useState<BookCaseListType[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const BOOKS_PER_ROW = 15;
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [startY, setStartY] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchBooks = async () => {
+      try {
+        setIsLoading(true);
+        const response = await bookAPI.getBookCaseList(
+          tokenService.getUser()?.id,
+          1,
+          1000,
+        );
+        setBooks(response.data);
+      } catch (error) {
+        console.error('책 목록을 가져오는데 실패했습니다:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchBooks();
+  }, []);
+
+  const handleDragStart = (clientX: number, clientY: number) => {
+    setIsDragging(true);
+    if (containerRef.current) {
+      setStartX(clientX - containerRef.current.offsetLeft);
+      setStartY(clientY - containerRef.current.offsetTop);
+      setScrollLeft(containerRef.current.scrollLeft);
+      setScrollTop(containerRef.current.scrollTop);
+    }
+  };
+
+  const handleDragMove = (clientX: number, clientY: number) => {
+    if (!isDragging) return;
+
+    if (containerRef.current) {
+      const x = clientX - containerRef.current.offsetLeft;
+      const y = clientY - containerRef.current.offsetTop;
+      const walkX = (x - startX) * 2;
+      const walkY = (y - startY) * 2;
+
+      containerRef.current.scrollLeft = scrollLeft - walkX;
+      containerRef.current.scrollTop = scrollTop - walkY;
+    }
+  };
+
+  const handleDragEnd = () => {
+    setIsDragging(false);
+  };
+
+  const bookCaseRows = Math.max(3, Math.ceil(books.length / BOOKS_PER_ROW));
+
+  if (isLoading) {
+    return <div>로딩중...</div>;
+  }
 
   return (
-    <div className='w-full h-screen overflow-auto bg-white'>
-      {/* 책장 리스트 -> 아이템이 15개 이상일 때마다 추가하기 */}
-      <BookCaseList />
-      <BookCaseList />
-      <BookCaseList />
+    <div
+      ref={containerRef}
+      className='overflow-auto w-full h-screen bg-white select-none cursor-grab active:cursor-grabbing'
+      onMouseDown={(e) => handleDragStart(e.pageX, e.pageY)}
+      onMouseMove={(e) => handleDragMove(e.pageX, e.pageY)}
+      onMouseUp={handleDragEnd}
+      onMouseLeave={handleDragEnd}
+      onTouchStart={(e) =>
+        handleDragStart(e.touches[0].clientX, e.touches[0].clientY)
+      }
+      onTouchMove={(e) =>
+        handleDragMove(e.touches[0].clientX, e.touches[0].clientY)
+      }
+      onTouchEnd={handleDragEnd}>
+      {[...Array(bookCaseRows)].map((_, index) => {
+        const startIdx = index * BOOKS_PER_ROW;
+        const endIdx = startIdx + BOOKS_PER_ROW;
+        const rowBooks = books.slice(startIdx, endIdx);
 
+        return (
+          <BookCaseList
+            key={index}
+            page={index + 1}
+            books={rowBooks}
+          />
+        );
+      })}
       <ToolBoxButton onAddBook={() => setIsModalOpen(true)} />
 
       {isModalOpen && (

--- a/src/pages/bookcase/components/BookCaseList.tsx
+++ b/src/pages/bookcase/components/BookCaseList.tsx
@@ -1,4 +1,5 @@
-import { mockBooks } from '@/mocks/searchData';
+import { useEffect, useState, useRef } from 'react';
+
 import { useNavigate, useParams } from 'react-router-dom';
 import { tokenService } from '@/utils/token';
 
@@ -9,49 +10,54 @@ const truncateText = (text: string, maxLength: number) => {
   return text;
 };
 
-const BookCaseList = () => {
+interface BookCaseListProps {
+  page: number;
+  books: BookCaseListType[];
+}
+
+const BookCaseList = ({ page, books }: BookCaseListProps) => {
   const navigate = useNavigate();
   const { userId: pageUserId } = useParams<{ userId: string }>();
   const myUserId = tokenService.getUser()?.id;
 
-  const handleBookClick = (bookId: string) => {
-    // 현재 페이지의 userId와 로그인한 사용자의 userId가 같으면 내 서평으로 이동
+  const handleBookClick = (bookId: number | string) => {
     if (pageUserId === myUserId) {
       navigate(`/book/${bookId}`);
     } else {
-      // 다른 사용자의 서평이면 user/:userId 포함하여 이동
       navigate(`/book/${bookId}/user/${pageUserId}`);
     }
   };
 
   return (
     <ul className='w-[5300px] h-[420px] bg-[#D1E5F1] shadow-[inset_0px_4px_20px_5px_rgba(30,146,215,0.20)] flex items-end gap-14 px-20'>
-      {mockBooks.length === 0 ? (
-        // 책장이 비어있을 때
-        <div className='relative item-row'>
-          <li className='text-2xl text-white cursor-pointer w-50 h-70 rounded-2xl book-gradient drop-shadow-book item-middle'>
-            ｡°(っ°´o`°ｃ)°｡
-            <div className='absolute bottom-0 w-full bg-white h-13 rounded-b-2xl'></div>
-          </li>
-          <span className='text-xl text-[#2656CD]/70 absolute -bottom-10'>
-            책장이 텅 비어있습니다.
-          </span>
+      {books.length === 0 && page === 2 ? (
+        // 두 번째 책장이고 비어있을 때만 메시지 표시
+        <div className='flex relative justify-center items-center w-full'>
+          <div className='text-center'>
+            <li className='text-2xl text-white rounded-2xl cursor-pointer w-50 h-70 book-gradient drop-shadow-book item-middle'>
+              ｡°(っ°´o`°ｃ)°｡
+              <div className='absolute bottom-0 w-full bg-white rounded-b-2xl h-13'></div>
+            </li>
+            <span className='text-xl text-[#2656CD]/70 block mt-4'>
+              책장이 텅 비어있습니다.
+            </span>
+          </div>
         </div>
       ) : (
         // 책 목록 표시
-        mockBooks.map((book) =>
+        books.map((book) =>
           book.imageURL ? (
             // 이미지가 있는 경우
             <li
               key={book.id}
               onClick={() => handleBookClick(book.id)}
-              className='relative text-white transition-transform duration-300 transform cursor-pointer w-50 h-70 rounded-2xl book-gradient drop-shadow-book hover:-rotate-6 hover:scale-105 hover:-translate-y-4'>
+              className='relative text-white rounded-2xl transition-transform duration-300 transform cursor-pointer w-50 h-70 book-gradient drop-shadow-book hover:-rotate-6 hover:scale-105 hover:-translate-y-4'>
               <img
                 src={book.imageURL}
                 alt={book.title}
                 className='object-cover w-full h-full rounded-2xl'
               />
-              <div className='absolute bottom-0 w-full p-2 bg-white h-13 rounded-b-2xl'>
+              <div className='absolute bottom-0 p-2 w-full bg-white rounded-b-2xl h-13'>
                 <p className='text-sm text-[#2656CD] font-medium truncate'>
                   {book.title}
                 </p>
@@ -63,8 +69,8 @@ const BookCaseList = () => {
             <li
               key={book.id}
               onClick={() => handleBookClick(book.id)}
-              className='relative text-white transition-transform duration-300 transform bg-white cursor-pointer w-18 h-70 rounded-2xl drop-shadow-book hover:-rotate-6 hover:scale-105 hover:-translate-y-4'>
-              <div className='flex flex-col items-center justify-between w-full h-full pt-4 text-center pb-14'>
+              className='relative text-white bg-white rounded-2xl transition-transform duration-300 transform cursor-pointer w-18 h-70 drop-shadow-book hover:-rotate-6 hover:scale-105 hover:-translate-y-4'>
+              <div className='flex flex-col justify-between items-center pt-4 pb-14 w-full h-full text-center'>
                 <h3 className='text-lg vertical-text font-medium mb-2 text-[#2656CD]'>
                   {truncateText(book.title, 6)}
                 </h3>
@@ -72,7 +78,7 @@ const BookCaseList = () => {
                   {truncateText(book.author, 8)}
                 </p>
               </div>
-              <div className='absolute bottom-0 w-full p-2 text-center book-gradient h-13 rounded-b-2xl'>
+              <div className='absolute bottom-0 p-2 w-full text-center rounded-b-2xl book-gradient h-13'>
                 <p className='text-xs text-[#2656CD]'>
                   {book.publishedDate.split('.')[0]}
                 </p>

--- a/src/types/book.d.ts
+++ b/src/types/book.d.ts
@@ -18,3 +18,15 @@ interface ReviewType {
   topic: string;
   coverColor: string;
 }
+
+interface BookCaseListType {
+  id: number;
+  title: string;
+  author: string;
+  publisher: string;
+  publishedDate: string;
+  imageURL: string;
+  category: string;
+  page: number;
+};
+


### PR DESCRIPTION
## ✨ 반영 브랜치
`fix/book-style` -> `dev`

## 📝 설명
- 책장 페이지의 도서 조회 로직 수정
- 책장 페이지에서 드래그 기능을 추가

## ✅ 변경 사항
- [x] 도서 조회 로직 개선
  - 한 번의 API 호출로 모든 도서 데이터 조회
  - 페이지별 도서 데이터 분배 로직 추가
  - 빈 책장 메시지 위치 수정 (두 번째 책장에 표시)
- [x] 책장 드래그 기능 추가
  - 마우스/터치 드래그로 책장 스크롤 가능
  - 드래그 중 커서 스타일 변경
  - 부드러운 스크롤 효과 적용
- [x] 코드 구조 개선
  - BookCaseList 컴포넌트 Props 타입 정의
  - 불필요한 상태 및 API 호출 제거

## 💬 PR 포인트
- 드래그 기능이 자연스럽게 동작하는지 확인 부탁드립니다

## 📢 관련 이슈
#57