### PR TITLE
[fix/datalist] :rotating_light:Fix: datalist 컴포넌트 수정(userId props 추가) / cd 삭제 API 추가

### DIFF
--- a/src/apis/cd.ts
+++ b/src/apis/cd.ts
@@ -194,8 +194,8 @@ export const getCdRack = async (
   cursor?: number,
 ) => {
   const url = cursor
-    ? `/${API_URL}/my-cd?userId=${userId}&size=${size}&cursor=${cursor}`
-    : `/${API_URL}/my-cd?userId=${userId}&size=${size}0`;
+    ? `/${API_URL}/my-cd?userId=${userId}&size=${size || 14}&cursor=${cursor}`
+    : `/${API_URL}/my-cd?userId=${userId}&size=${size || 14}`;
 
   const response = await axiosInstance.get(url);
 
@@ -312,4 +312,17 @@ export const deleteTemplate = async (myCdId: number, userId: number) => {
     `/${API_URL}/my-cd/${myCdId}/template?userId=${userId}`,
   );
   return response;
+};
+
+/**
+ * CD 삭제 API
+ * @param userId 사용자 ID
+ * @param myCdIds 삭제할 CD ID 목록 (쉼표로 구분된 문자열)
+ * @returns
+ */
+export const deleteCdsFromMyRack = async (userId: number, myCdIds: string) => {
+  const response = await axiosInstance.delete(
+    `/${API_URL}/my-cd?userId=${userId}&myCdIds=${myCdIds}`,
+  );
+  return response.data;
 };

--- a/src/components/datalist/DataList.tsx
+++ b/src/components/datalist/DataList.tsx
@@ -6,6 +6,7 @@ import { SearchInput } from '@components/search-modal/SearchInput';
 import { useDebounce } from '@hooks/useDebounce';
 import SkeletonItem from '@components/SkeletonItem';
 import { bookAPI } from '@/apis/book';
+import { deleteCdsFromMyRack } from '@/apis/cd';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 interface DataListProps {
@@ -15,6 +16,7 @@ interface DataListProps {
   hasMore: boolean;
   isLoading: boolean;
   fetchMore: () => void;
+  userId: number;
 }
 
 export default function DataList({
@@ -24,6 +26,7 @@ export default function DataList({
   hasMore,
   isLoading: isLoadingMore,
   fetchMore,
+  userId,
 }: DataListProps) {
   const isBook = type === 'book' ? true : false;
   const mainColor = isBook ? '#2656CD' : '#7838AF';
@@ -78,9 +81,16 @@ export default function DataList({
 
   const handleDelete = async () => {
     try {
-      if (isBook && selectedIds.length > 0) {
-        const myBookIds = selectedIds.join(',');
-        await bookAPI.deleteBookFromMyBook('1', myBookIds);
+      if (selectedIds.length > 0) {
+        if (isBook) {
+          // 도서 삭제 로직
+          const myBookIds = selectedIds.join(',');
+          await bookAPI.deleteBookFromMyBook(String(userId), myBookIds);
+        } else {
+          // CD 삭제 로직
+          const myCdIds = selectedIds.join(',');
+          await deleteCdsFromMyRack(userId, myCdIds);
+        }
 
         const updatedDatas = filteredDatas.filter(
           (data) => !selectedIds.includes(data.id),

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,0 +1,64 @@
+import DataList from '@components/datalist/DataList';
+import React, { useState, useEffect } from 'react';
+
+const TestPage = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+  const [cdList, setCdList] = useState<DataListInfo[]>([]);
+
+  const generateDummyData = (cursorId: number) => {
+    return Array.from({ length: 14 }, (_, index) => ({
+      id: String(cursorId + index + 1),
+      title: `Test Song ${cursorId + index + 1}`,
+      artist: `Artist ${cursorId + index + 1}`,
+      released_year: '2024',
+      album: `Album ${cursorId + index + 1}`,
+    }));
+  };
+
+  useEffect(() => {
+    const initialData = generateDummyData(0);
+    setCdList(initialData);
+    setCursor(14); // 다음 페이지의 시작점
+  }, []);
+
+  // 추가 데이터 로드 함수
+  const fetchMore = async () => {
+    if (isLoading || !hasMore) return;
+
+    setIsLoading(true);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const newData = generateDummyData(cursor || 0);
+
+      // 더미 데이터가 50개를 넘어가면 더 이상 로드하지 않음
+      if (cdList.length + newData.length >= 50) {
+        setHasMore(false);
+      }
+
+      setCdList((prev) => [...prev, ...newData]);
+      setCursor((prev) => (prev || 0) + 14);
+    } catch (error) {
+      console.error('Error fetching more data:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className='w-screen h-screen bg-gray-100'>
+      <DataList
+        datas={cdList}
+        type='cd'
+        hasMore={hasMore}
+        isLoading={isLoading}
+        fetchMore={fetchMore}
+        userId={2}
+      />
+    </div>
+  );
+};
+
+export default TestPage;

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -187,6 +187,7 @@ const BookCasePage = () => {
             hasMore={false}
             isLoading={isLoading}
             fetchMore={() => {}}
+            userId={user.userId}
           />
         </ModalBackground>
       )}

--- a/src/pages/cd/components/CdPlayer.tsx
+++ b/src/pages/cd/components/CdPlayer.tsx
@@ -17,6 +17,7 @@ import { getCdRack } from '@apis/cd';
 export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
   const [isCdListOpen, setIsCdListOpen] = useState(false);
   const [cdDatas, setCdDatas] = useState(null);
+  const [formattedCds, setFormattedCds] = useState<DataListInfo[]>([]);
 
   // cd 초기상태 관리
   const [cdReady, setCdReady] = useState({
@@ -50,14 +51,6 @@ export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
     },
   };
 
-  // const formattedCds = mockCD.data.map((cd) => ({
-  //   id: String(cd.myCdId),
-  //   title: cd.title,
-  //   artist: cd.artist,
-  //   released_year: cd.releaseDate,
-  //   album: cd.album,
-  // }));
-
   const progressStyle = {
     background: `linear-gradient(to right, #162C63 ${cdPlayer.progress}%, #E5E7EB ${cdPlayer.progress}%)`,
   };
@@ -66,6 +59,14 @@ export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
     const fetchData = async () => {
       try {
         const result = await getCdRack(userId);
+        const formatted = result.data.map((cd) => ({
+          id: String(cd.myCdId),
+          title: cd.title,
+          artist: cd.artist,
+          released_year: cd.releaseDate,
+          album: cd.album,
+        }));
+        setFormattedCds(formatted);
       } catch (error) {
         console.error(error);
       }
@@ -244,8 +245,8 @@ export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
           />
         </div>
 
-        <div className=' w-full h-full relative'>
-          <div className='flex items-center absolute bottom-10  left-10 '>
+        <div className='relative w-full h-full '>
+          <div className='absolute flex items-center bottom-10 left-10 '>
             {/* 앨범 이미지 */}
             <img
               className='w-20 h-20 rounded-[8px]'
@@ -253,7 +254,7 @@ export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
               alt='CD 앨범 이미지'
             />
             {/* 음량 */}
-            <div className=' flex justify-center items-center gap-2 pl-13 '>
+            <div className='flex items-center justify-center gap-2 pl-13'>
               {cdReady.isMuted ? (
                 <button
                   onClick={() =>
@@ -350,6 +351,7 @@ export default function CdPlayer({ cdInfo }: { cdInfo: CDInfo }) {
             hasMore={false}
             isLoading={false}
             fetchMore={() => {}}
+            userId={userId}
           />
         </ModalBackground>
       )}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -12,6 +12,7 @@ import RequireAuth from './layout/RequireAuth';
 import ProfileCardPage from '@pages/profile-card/ProfileCardPage';
 import ProfileCardEditPage from '@pages/profile-card-edit/ProfileCardEditPage';
 import Redirection from '@pages/login/components/Redirection';
+import TestPage from '@pages/TestPage';
 
 const Router = () => {
   return (
@@ -46,6 +47,10 @@ const Router = () => {
           <Route
             path='/profile/:userId/edit'
             element={<ProfileCardEditPage />}
+          />
+          <Route
+            path='/test'
+            element={<TestPage />}
           />
         </Route>
         {/* 내 서평 보기/수정 */}


### PR DESCRIPTION
## ✨ 반영 브랜치
`fix/datalist` -> `dev`

## 📝 설명
DataList 컴포넌트에 CD 삭제 기능을 추가하고 userId prop 추가
무한 스크롤 기능 테스트

## ✅ 변경 사항
- [x] CD 삭제 API 추가 (`deleteCdsFromMyRack`)
- [x] DataList 컴포넌트에 userId prop 추가
- [x] DataList의 handleDelete 함수에 CD 삭제 로직 추가
- [x] 도서/CD 삭제 시 실제 사용자 ID 사용하도록 수정
- [x] TestPage와 CdPlayer에서 DataList 사용 시 userId 전달하도록 수정

## 💬 PR 포인트 & 질문사항
1. 기존 도서 삭제 로직은 그대로 유지하면서 CD 삭제 기능을 추가했습니다.
   - `isBook` 조건에 따라 각각 다른 API를 호출하도록 구현
   - 삭제 후 목록 업데이트는 동일한 로직 사용
  
2. getCdRack 호출 API에 기본값 14 추가
 - datalist를 불러올 때 무한 스크롤을 트리거 시키려면 기본 스크롤이 있어야 해서 두 페이지 단위인 14개씩 호출하도록 했습니다. (cd.ts 197 -198라인)
 ```
    ? `/${API_URL}/my-cd?userId=${userId}&size=${size || 14}&cursor=${cursor}`
    : `/${API_URL}/my-cd?userId=${userId}&size=${size || 14}`;
```

4. 테스트 관련:
   - TestPage에서 무한 스크롤과 함께 삭제 기능 테스트 가능
   - 실제 CD 목록에서도 정상 작동 확인

## 📢 이슈 정보
#116 