### PR TITLE
[fix/profile-card] 팔로우 관계에 따라 프로필카드 버튼 렌더링

### DIFF
--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -3,7 +3,7 @@ import axiosInstance from './axiosInstance';
 import { BookType, ReviewType } from '@/types/book';
 
 const ALADIN_KEY = import.meta.env.VITE_ALADIN_KEY;
-const API_URL = 'api';
+const API_URL = 'mock';
 
 export const bookAPI = {
   // ------------------------------ 검색 ------------------------------

--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -102,7 +102,7 @@ export const profileAPI = {
     formData.append('image', image);
 
     const { data } = await axiosInstance.put<{ imageUrl: string }>(
-      `${API_URL}/users/profile/image`,
+      `${API_URL}/users/image`,
       formData,
       {
         headers: {

--- a/src/pages/book-viewer/BookViewerPage.tsx
+++ b/src/pages/book-viewer/BookViewerPage.tsx
@@ -20,7 +20,7 @@ const BookViewerPage = ({ reviewData, bookId }: BookViewerPageProps) => {
           alt={reviewData.bookTitle}
         />
       </figure>
-      <article className='w-1/2 h-full'>
+      <article className='w-1/2 h-full scroll-smooth'>
         <BookReviewDisplay
           mode='view'
           previewData={reviewData}

--- a/src/pages/book-viewer/components/BookReviewDisplay.tsx
+++ b/src/pages/book-viewer/components/BookReviewDisplay.tsx
@@ -94,7 +94,9 @@ const BookReviewDisplay = ({
   };
 
   return (
-    <div className='relative h-full overflow-x-hidden'>
+    <div
+      className='relative h-full overflow-x-hidden overflow-y-auto'
+      style={{ scrollBehavior: 'smooth' }}>
       <BookHeader
         title={displayData.title}
         reviewFields={REVIEW_FIELDS}
@@ -104,7 +106,10 @@ const BookReviewDisplay = ({
 
       <article
         className='absolute flex flex-col w-full gap-4 rounded-tl-[80px] top-[70%] min-h-[30%] px-24 py-16 overflow-x-hidden'
-        style={{ backgroundColor: `${colors.surface}` }}>
+        style={{
+          backgroundColor: `${colors.surface}`,
+          scrollBehavior: 'smooth',
+        }}>
         <BookInfo
           publishedDate={displayData.publishedDate}
           bookTitle={displayData.bookTitle}

--- a/src/pages/book-viewer/components/ReviewContent.tsx
+++ b/src/pages/book-viewer/components/ReviewContent.tsx
@@ -52,9 +52,9 @@ export const ReviewContent = ({
   onDelete,
 }: ReviewContentProps) => (
   <>
-    <div className='mb-12 item-between'>
+    <div className='items-end py-8 mb-12 item-between'>
       <p
-        className='py-16 text-sm'
+        className='text-sm '
         style={{ color: `${colors.primary}80` }}>
         {reviewData.writeDateTime}
       </p>

--- a/src/pages/profile-card/ProfileCardPage.tsx
+++ b/src/pages/profile-card/ProfileCardPage.tsx
@@ -145,6 +145,7 @@ const ProfileCardPage = () => {
         <ProfileButtons
           userId={userId}
           isMyProfile={isMyProfile}
+          isMatched={profile.following}
           onProfileUpdate={updateProfile}
         />
       )}

--- a/src/pages/profile-card/components/GenreCard.tsx
+++ b/src/pages/profile-card/components/GenreCard.tsx
@@ -7,12 +7,12 @@ const GenreCard = ({ title, genres }: GenreCardProps) => {
           genres.map((genre, index) => (
             <span
               key={`${genre}-${index}`}
-              className='text-xs text-[#3E507D] bg-[#73A1F7]/20 rounded-full px-2 py-1 min-w-15 item-middle font-medium'>
+              className='text-xs text-[#3E507D] bg-[#73A1F7]/20 rounded-full px-2 py-1 min-w-15 item-middle font-medium item-middle text-center   '>
               {genre}
             </span>
           ))
         ) : (
-          <span className='text-xs text-[#3E507D] bg-[#73A1F7]/20 rounded-full px-2 py-1 min-w-15 item-middle font-medium'>
+          <span className='text-xs text-[#3E507D] bg-[#73A1F7]/20 rounded-full px-2 py-1 min-w-15 item-middle font-medium item-middle text-center'>
             딱 맞는 취향을 찾는 중
           </span>
         )}

--- a/src/types/profile.d.ts
+++ b/src/types/profile.d.ts
@@ -64,3 +64,19 @@ interface UpdateProfileRequest {
   musicGenres?: string[];
   bookGenres?: string[];
 }
+
+interface UserProfileResponse {
+  id: string;
+  nickname: string;
+  profileImage: string;
+  bio: string;
+  musicGenres: string[];
+  bookGenres: string[];
+  recommendedUsers?: {
+    userId: number;
+    nickname: string;
+    profileImage: string;
+  }[];
+  following: boolean;
+  myProfile: boolean;
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/profile-card -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
팔로우 관계에 따라 프로필카드 버튼 렌더링
도서 - 뷰어 부분 부드러운 스크롤 적용 및 여백 조정

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#118