### PR TITLE
[fix/notification/profile-card] Fix/notification/profile card

### DIFF
--- a/src/components/header/menus/notification-modal/components/NotificationItem.tsx
+++ b/src/components/header/menus/notification-modal/components/NotificationItem.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatToKoreanFullDate } from '@/utils/dateFormat';
 import { NotificationMessage } from './NotificationMessage';
+import { useUserStore } from '@/store/useUserStore';
 
 interface NotificationItemProps {
   notification: Notification;
@@ -13,6 +14,7 @@ interface NotificationItemProps {
 export const NotificationItem = memo(
   ({ notification, onRead, activeTab, onClose }: NotificationItemProps) => {
     const navigate = useNavigate();
+    const { user } = useUserStore();
 
     const handleClick = () => {
       // 읽지 않음 탭에서만 read 요청을 보냄
@@ -23,7 +25,7 @@ export const NotificationItem = memo(
       // 알림 타입에 따른 이동 처리
       switch (notification.type) {
         case 'GUESTBOOK':
-          navigate(`/room/${notification.targetId}`);
+          navigate(`/room/${user.userId}`);
           break;
         case 'MUSIC_COMMENT':
           // navigate(`/cd/${cdId}/user/${notification.targetId}`);

--- a/src/pages/profile-card-edit/components/ProfileForm.tsx
+++ b/src/pages/profile-card-edit/components/ProfileForm.tsx
@@ -23,10 +23,10 @@ export const ProfileForm = ({
           onChange={(e) => onNicknameChange(e.target.value)}
           placeholder='닉네임을 입력해주세요'
           className='w-full px-4 py-2 bg-[#4E7ACF]/5 rounded-lg outline-none border-2 border-transparent focus:border-[#73A1F7] transition-colors text-[#3E507D]'
-          maxLength={10}
+          maxLength={15}
         />
         <span className='text-sm text-[#3E507D]/60 text-right'>
-          {nickname.length}/10
+          {nickname.length}/15
         </span>
       </div>
 


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/notification/profile-card` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
프로필 카드 - 닉네임 제한 15글자로 수정
방명록 라우팅 경로 targetId -> senderId로 수정

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
기존의 '방명록에 새로운 알림이 있습니다' 알림이 잘못된 라우팅 경로로 되어있어서 올바르게 수정했습니다.
(기존 : 알림 아이디로 라우팅 -> 수정 : 나의 room page로 이동)

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#130 