### PR TITLE
[fix/book] :sparkles:Feature: 도서 장르 키워드 8글자 이상일 때 장르에 표시하지 않도록 필터링

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -19,6 +19,7 @@ export const useSearch = (type: 'CD' | 'BOOK') => {
   const [results, setResults] = useState<SearchItemType[]>([]);
 
   const debouncedQuery = useDebounce(query, 1500);
+  const GENRE_MAX_LENGTH = 8;
 
   // 책 검색 API 호출
   const searchBooks = async (
@@ -44,7 +45,10 @@ export const useSearch = (type: 'CD' | 'BOOK') => {
           date: book.pubDate,
           imageUrl: book.cover,
           type: 'BOOK' as const,
-          genres: book.categoryName.split('>').slice(1),
+          genres: book.categoryName
+            .split('>')
+            .slice(1)
+            .filter((genre) => genre.trim().length < GENRE_MAX_LENGTH),
         }));
     } catch (error: unknown) {
       const apiError = error as ApiError;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/book` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
도서 장르 키워드 8글자 이상일 때 장르에 표시하지 않도록 필터링
회의를 통해 결정한대로 도서 장르의 키워드가 공백 및 특수문자 포함 8글자 이상일때는 해당 장르를 필터링하도록 구현했습니다

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#191 