### PR TITLE
Update workflow.yml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,17 +12,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20' # react-router 요구사항에 맞게 Node.js 20으로 변경
-          cache: 'pnpm' # 또는 yarn, pnpm 등 사용 중인 패키지 매니저
-
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 10
-          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
 현재는 Node.js 설정에서 pnpm 캐시를 사용하려고 하는데, 아직 pnpm이 설치되어 있지 않아서 문제가 발생하고 있습니다.

1. pnpm 설치 단계를 Node.js 설정 전으로 이동했습니다. run_install: false 옵션을 제거했습니다 (불필요한 옵션이었습니다).

설치 순서를 다음과 같이 변경했습니다:
먼저 코드를 체크아웃
pnpm 설치
Node.js 설정 (이때 pnpm 캐시 사용)
그 다음 의존성 설치 및 빌드